### PR TITLE
Add filename into file form part

### DIFF
--- a/creates/uploadFile.js
+++ b/creates/uploadFile.js
@@ -11,7 +11,11 @@ const uploadFile = (z, bundle) => {
   // file will in fact be an url where the file data can be downloaded from
   // which we do via a stream created by NPM's request package
   // (form-data doesn't play nicely with z.request)
-  formData.append('file', request(bundle.inputData.file));
+  formData.append('file', request(bundle.inputData.file),
+    { 
+        filename: bundle.inputData.filename,
+        //FormData also supports contentType and other form part data.
+    });
 
   if (bundle.inputData.name) {
     formData.append('name', bundle.inputData.name);


### PR DESCRIPTION
File form parts can include data like filename, filepath and size.  Including a filename with each part (rather than outside the part in separate parts) makes multiple file uploading easier.  Also many file receiving mechanisms (e.g. PHP's $_FILES) use this data.  Form-data supports this.
https://www.npmjs.com/package/form-data.  I noticed that with form-data, if a filename is not included, the part's filename header seems to include a very long garbage-y filename.